### PR TITLE
separate stderr from command output

### DIFF
--- a/cmd/kcloud/command.go
+++ b/cmd/kcloud/command.go
@@ -29,7 +29,8 @@ func RunCommand(command string, args ...string) ([]byte, error) {
 		fmt.Println("debug: ", QuoteCommand(command, args...))
 	}
 	cmd := exec.Command(command, args...)
-	return cmd.CombinedOutput()
+	cmd.Stderr = os.Stderr
+	return cmd.Output()
 }
 
 // QuoteCommand writes the given command with quotes around the args for convenience


### PR DESCRIPTION
If a command results in output to stderr, that output should be printed for the user instead of trying to parse it because it may not follow the same format as the standard command output.